### PR TITLE
Fix Cellular_ATIsPrefixPresent function

### DIFF
--- a/vendors/aws/modules/3gpp/ports/cellular/src/cellular_at_core.c
+++ b/vendors/aws/modules/3gpp/ports/cellular/src/cellular_at_core.c
@@ -503,7 +503,16 @@ CellularATError_t Cellular_ATGetSpecificNextTok( char ** ppString,
     if( atStatus == CELLULAR_AT_SUCCESS )
     {
         dataStrlen = ( uint16_t ) strlen( *ppString );
-        tok = strtok( *ppString, pDelimiter );
+
+        if( ( **ppString ) == ( *pDelimiter ) )
+        {
+            **ppString = '\0';
+            tok = *ppString;
+        }
+        else
+        {
+            tok = strtok( *ppString, pDelimiter );
+        }
 
         if( tok == NULL )
         {


### PR DESCRIPTION
Fix Cellular_ATIsPrefixPresent with the string with empty token length.
For example, +CPSMS:0,,,"00000100","00001110"

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.